### PR TITLE
feat: Added DNSSEC-types

### DIFF
--- a/DNS/Type.py
+++ b/DNS/Type.py
@@ -42,6 +42,12 @@ MAILB = 253     # A request for mailbox-related records (MB, MG or MR)
 MAILA = 254     # A request for mail agent RRs (Obsolete - see MX)
 ANY = 255       # A request for all records
 
+# DNSSEC
+DS = 43
+DNSKEY = 48
+NSEC = 47
+NSEC3 = 50
+
 # Construct reverse mapping dictionary
 
 _names = dir()


### PR DESCRIPTION
Not having DNSSEC RR-types in the library makes py3dns non-feasible for any usage with secured DNS. Having them in today's Internet is a must.

This minor change improves library's capabilities towards future use.